### PR TITLE
:sparkles: verify firebase jwt on api routes, cookies, incremental static regeneration page

### DIFF
--- a/components/AddSiteModal.js
+++ b/components/AddSiteModal.js
@@ -41,7 +41,7 @@ const AddSiteModal = ({ children }) => {
       isClosable: true
     });
     mutate(
-      '/api/sites',
+      ['/api/sites', auth.user.token],
       async (data) => {
         return { sites: [...data.sites, newSite] };
       },

--- a/components/FeedbackLink.js
+++ b/components/FeedbackLink.js
@@ -7,7 +7,7 @@ export default function FeedbackLink({ siteId }) {
         Leave a comment →
       </Link>
       <Link fontSize="xs" color="blackAlpha.500" href="/">
-        Powered by Fast Feedback
+        Powered by Express Feedback
       </Link>
     </Flex>
   );

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext, createContext } from 'react';
+import cookie from 'js-cookie';
 
 import { createUser } from './db';
 import firebase from './firebase';
@@ -20,12 +21,20 @@ function useProvideAuth() {
   const handleUser = (rawUser) => {
     if (rawUser) {
       const user = formatUser(rawUser);
+      const { token, ...userWithoutToken } = user;
 
-      createUser(user.uid, user);
+      createUser(user.uid, userWithoutToken);
       setUser(user);
+
+      cookie.set('express-feedback-auth', true, {
+        expires: 1
+      });
+
       return user;
     } else {
       setUser(false);
+      cookie.remove('express-feedback-auth');
+
       return false;
     }
   };
@@ -79,6 +88,7 @@ const formatUser = (user) => {
     email: user.email,
     name: user.displayName,
     provider: user.providerData[0].providerId,
-    photoUrl: user.photoURL
+    photoUrl: user.photoURL,
+    token: user.ya
   };
 };

--- a/lib/db-admin.js
+++ b/lib/db-admin.js
@@ -1,10 +1,10 @@
 import { compareDesc, parseISO } from 'date-fns';
 
-import firebase from './firebase-admin';
+import { db } from './firebase-admin';
 
 export async function getAllFeedback(siteId) {
   try {
-    const snapshot = await firebase
+    const snapshot = await db
       .collection('feedback')
       .where('siteId', '==', siteId)
       .get();
@@ -27,7 +27,7 @@ export async function getAllFeedback(siteId) {
 
 export async function getAllSites() {
   try {
-    const snapshot = await firebase.collection('sites').get();
+    const snapshot = await db.collection('sites').get();
     const sites = [];
 
     snapshot.forEach((doc) => {
@@ -38,4 +38,18 @@ export async function getAllSites() {
   } catch (error) {
     return { error };
   }
+}
+
+export async function getUserSites(userId) {
+  const snapshot = await db
+    .collection('sites')
+    .where('authorId', '==', userId)
+    .get();
+  const sites = [];
+
+  snapshot.forEach((doc) => {
+    sites.push({ id: doc.id, ...doc.data() });
+  });
+
+  return { sites };
 }

--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -10,4 +10,7 @@ if (!admin.apps.length) {
   });
 }
 
-export default admin.firestore();
+const db = admin.firestore();
+const auth = admin.auth();
+
+export { db, auth };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "emotion-theming": "^10.0.27",
     "firebase": "^7.17.1",
     "firebase-admin": "^8.12.1",
+    "js-cookie": "^2.2.1",
     "next": "^9.4.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/pages/api/feedback/[siteId].js
+++ b/pages/api/feedback/[siteId].js
@@ -1,3 +1,4 @@
+import { db } from '@/lib/firebase-admin';
 import { getAllFeedback } from '@/lib/db-admin';
 
 export default async (req, res) => {

--- a/pages/api/sites.js
+++ b/pages/api/sites.js
@@ -1,11 +1,13 @@
-import { getAllSites } from '@/lib/db-admin';
+import { auth } from '@/lib/firebase-admin';
+import { getUserSites } from '@/lib/db-admin';
 
-export default async (_, res) => {
-  const { sites, error } = await getAllSites();
+export default async (req, res) => {
+  try {
+    const { uid } = await auth.verifyIdToken(req.headers.token);
+    const sites = await getUserSites(uid);
 
-  if (error) {
+    res.status(200).json(sites);
+  } catch (error) {
     res.status(500).json({ error });
   }
-
-  res.status(200).json({ sites });
 };

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -8,8 +8,8 @@ import DashboardShell from '@/components/DashboardShell';
 import SiteTableSkeleton from '@/components/SiteTableSkeleton';
 
 const Dashboard = () => {
-  const auth = useAuth();
-  const { data } = useSWR('/api/sites', Fetcher);
+  const { user } = useAuth();
+  const { data } = useSWR(user ? ['/api/sites', user.token] : null, Fetcher);
 
   if (!data) {
     return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,43 +1,75 @@
 import Head from 'next/head';
+import { Button, Flex, Text, Icon, Link } from '@chakra-ui/core';
 
-import { Button, Flex, Icon } from '@chakra-ui/core';
 import { useAuth } from '@/lib/auth';
 
 const Home = () => {
   const auth = useAuth();
 
   return (
-    <>
-      <Flex
-        as="main"
-        direction="column"
-        align="center"
-        justify="center"
-        h="100vh"
-      >
-        <Head>
-          <title>Express Feedback</title>
-        </Head>
-        <Icon color="black" name="logo" size="64px" />
-        {auth.user ? (
-          <Button as="a" mt={4} size="sm" href="/dashboard">
-            View Dashboard
+    <Flex
+      as="main"
+      direction="column"
+      align="center"
+      justify="center"
+      h="100vh"
+      maxW="400px"
+      margin="0 auto"
+    >
+      <Head>
+        <title>Express Feedback</title>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              if (document.cookie && document.cookie.includes('express-feedback-auth')) {
+                window.location.href = "/dashboard"
+              }
+              `
+          }}
+        />
+      </Head>
+      <Icon color="black" name="logo" size="42px" mb={2} />
+      <br />
+      <Text mb={4} textAlign="justify">
+        <Text as="span" fontWeight="bold" display="inline">
+          Express Feedback
+        </Text>
+        {' is built by '}
+        <Link
+          href="https://github.com/gilangadam"
+          isExternal
+          textDecoration="underline"
+        >
+          Gilang Adam
+        </Link>
+        {` with guidance from `}
+        <Link
+          href="https://react2025.com"
+          isExternal
+          textDecoration="underline"
+        >
+          React 2025
+        </Link>
+        {`. It's the easiest way to add feedback, comments, or reviews to your static site.`}
+      </Text>
+      {auth.user ? (
+        <Button as="a" mt={4} size="sm" href="/dashboard">
+          View Dashboard
+        </Button>
+      ) : (
+        <>
+          <Button mt={4} size="sm" onClick={(e) => auth.signInWithGitHub()}>
+            Github Sign In
           </Button>
-        ) : (
-          <>
-            <Button mt={4} size="sm" onClick={(e) => auth.signInWithGitHub()}>
-              Github Sign In
-            </Button>
-            <Button mt={4} size="sm" onClick={(e) => auth.signInWithGoogle()}>
-              Google Sign In
-            </Button>
-            <Button mt={4} size="sm" onClick={(e) => auth.signInWithTwitter()}>
-              Twitter Sign In
-            </Button>
-          </>
-        )}
-      </Flex>
-    </>
+          <Button mt={4} size="sm" onClick={(e) => auth.signInWithGoogle()}>
+            Google Sign In
+          </Button>
+          <Button mt={4} size="sm" onClick={(e) => auth.signInWithTwitter()}>
+            Twitter Sign In
+          </Button>
+        </>
+      )}
+    </Flex>
   );
 };
 

--- a/pages/p/[siteId].js
+++ b/pages/p/[siteId].js
@@ -14,7 +14,8 @@ export async function getStaticProps(context) {
   return {
     props: {
       initialFeedback: feedback
-    }
+    },
+    revalidate: 1
   };
 }
 

--- a/utils/fetcher.js
+++ b/utils/fetcher.js
@@ -1,5 +1,9 @@
-const Fetcher = async (...args) => {
-  const res = await fetch(...args);
+const Fetcher = async (url, token) => {
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: new Headers({ 'Content-Type': 'application/json', token }),
+    credentials: 'same-origin'
+  });
 
   return res.json();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4394,6 +4394,11 @@ jest-worker@24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
1. Only show sites for the current user: need context of user in API route
2. Enforce authentication on API routes: use Firebase to Verify API tokens
3. Redirect to /dashboard if you're already logged in (https://vercel.com/blog/simple-auth-with-magic-link-and-nextjs)
4. Try out [Incremental Static Regeneration](https://nextjs.org/blog/next-9-4#incremental-static-regeneration-beta)

>  commit no 7 is incorrect so it closed (see #7)